### PR TITLE
make message statuses to be non-paginatable

### DIFF
--- a/tests/cassettes/test_whispyr_messages/test_list_message_statuses.yaml
+++ b/tests/cassettes/test_whispyr_messages/test_list_message_statuses.yaml
@@ -15,14 +15,14 @@ interactions:
         authorization:
           - Basic VTUzUk40TTM6UDRaWlcwUkQ=
       method: GET
-      uri: https://api.whispir.com/workspaces/B6302F7C7B9A8982/messages/09CD9065116DF39F/messagestatus?apikey=V4L1D4P1K3Y&limit=20&offset=0
+      uri: https://api.whispir.com/workspaces/B6302F7C7B9A8982/messages/09CD9065116DF39F/messagestatus?apikey=V4L1D4P1K3Y
     response:
       body:
         string: |-
           {
             "messageStatuses" : [ {
               "link" : [ {
-                "uri" : "https://api.whispir.com/workspaces/B6302F7C7B9A8982/messages/09CD9065116DF39F/messagestatus?limit=20&offset=0&apikey=V4L1D4P1K3Y",
+                "uri" : "https://api.whispir.com/workspaces/B6302F7C7B9A8982/messages/09CD9065116DF39F/messagestatus?apikey=V4L1D4P1K3Y",
                 "rel" : "self",
                 "method" : "GET"
               } ],

--- a/whispyr/whispyr.py
+++ b/whispyr/whispyr.py
@@ -302,7 +302,7 @@ class Messages(Streamable, Collection):
     send = create
 
 
-class MessageStatuses(Collection):
+class MessageStatuses(Nonpaginatable, Collection):
 
     list_name = 'messageStatuses'
     resource = 'messagestatus'


### PR DESCRIPTION
whispir doesn't return pagination information for messagestatus endpoint