### PR TITLE
remove user-agents recordings from common fixtures

### DIFF
--- a/tests/cassettes/fixtures/workspace.yaml
+++ b/tests/cassettes/fixtures/workspace.yaml
@@ -10,8 +10,6 @@ interactions:
           - keep-alive
         Content-Type:
           - application/vnd.whispir.workspace-v1+json
-        User-Agent:
-          - whispyr/0.2.1
         authorization:
           - Basic VTUzUk40TTM6UDRaWlcwUkQ=
       method: GET
@@ -110,8 +108,6 @@ interactions:
           - keep-alive
         Content-Type:
           - application/vnd.whispir.workspace-v1+json
-        User-Agent:
-          - whispyr/0.2.1
         authorization:
           - Basic VTUzUk40TTM6UDRaWlcwUkQ=
       method: GET
@@ -210,8 +206,6 @@ interactions:
           - keep-alive
         Content-Type:
           - application/vnd.whispir.workspace-v1+json
-        User-Agent:
-          - whispyr/0.2.1
         authorization:
           - Basic VTUzUk40TTM6UDRaWlcwUkQ=
       method: GET


### PR DESCRIPTION
was supposed to be removed as part of #10 